### PR TITLE
New Mentions Class and Mentions shown on mentions page as message followed by conversation name

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -153,6 +153,30 @@ public class ChatServlet extends HttpServlet {
 
     messageStore.addMessage(message);
 
+    int startInd = cleanedMessageContent.indexOf('@');
+    int help = 0;
+    UserStore users = UserStore.getInstance();
+    int endInd = cleanedMessageContent.length();
+    while (startInd != -1 && startInd < cleanedMessageContent.length()-1){
+      for (int i = startInd+1; i < cleanedMessageContent.length(); i++){
+        if (!(cleanedMessageContent.charAt(i)>= 65 && cleanedMessageContent.charAt(i) <= 90)&&
+        !(cleanedMessageContent.charAt(i)>= 97 && cleanedMessageContent.charAt(i) <= 122) && !(cleanedMessageContent.charAt(i)>= 48
+        && cleanedMessageContent.charAt(i) <= 57)){
+          endInd = i;
+          break;
+        }
+      }
+      if (users.isUserRegistered(cleanedMessageContent.substring(startInd + 1, endInd))){
+        users.getUser(cleanedMessageContent.substring(startInd+1, endInd)).addMentions(cleanedMessageContent, conversationTitle);
+        help = endInd;
+      }
+      else{
+        help = startInd;
+      }
+      endInd = cleanedMessageContent.length();
+      startInd = cleanedMessageContent.indexOf('@', startInd + 1);
+    }
+
     // redirect to a GET request
     response.sendRedirect("/chat/" + conversationTitle);
   }

--- a/src/main/java/codeu/model/data/Mention.java
+++ b/src/main/java/codeu/model/data/Mention.java
@@ -1,0 +1,32 @@
+package codeu.model.data;
+
+/**
+ * Class representing a conversation, which can be thought of as a chat room. Conversations are
+ * created by a User and contain Messages.
+ */
+public class Mention {
+  public final String message;
+  public final String conversation;
+
+  /**
+   * Constructs a new Mention Object.
+   *
+   * @param message the message a user was mentioned in
+   * @param conversation the conversation title a user was mentioned in
+   */
+
+  public Mention(String msg, String conversation) {
+    this.message = msg;
+    this.conversation = conversation;
+  }
+
+  /** Returns message the user was mentioned in. */
+  public String getMessage() {
+    return message;
+  }
+
+  /** Returns the conversation title the user was mentioned in. */
+  public String getConversation() {
+    return conversation;
+  }
+}

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -16,6 +16,8 @@ package codeu.model.data;
 
 import java.time.Instant;
 import java.util.UUID;
+import java.util.ArrayList;
+import codeu.model.data.Mention;
 
 /** Class representing a registered user. */
 public class User {
@@ -23,6 +25,7 @@ public class User {
   private final String name;
   private final String passwordHash;
   private final Instant creation;
+  private ArrayList mentions;
 
   /**
    * Constructs a new User.
@@ -37,6 +40,7 @@ public class User {
     this.name = name;
     this.passwordHash = passwordHash;
     this.creation = creation;
+    this.mentions = new ArrayList<Mention>();
   }
 
   /** Returns the ID of this User. */
@@ -48,7 +52,7 @@ public class User {
   public String getName() {
     return name;
   }
-  
+
   /** Returns the password hash of this User. */
   public String getPasswordHash() {
     return passwordHash;
@@ -57,5 +61,14 @@ public class User {
   /** Returns the creation time of this User. */
   public Instant getCreationTime() {
     return creation;
+  }
+
+  /** Returns the mentions list of this User*/
+  public ArrayList<Mention> getMentions(){
+    return mentions;
+  }
+
+  public void addMentions(String msg, String conversation){
+    mentions.add(new Mention(msg, conversation));
   }
 }

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -17,6 +17,8 @@
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.data.Message" %>
 <%@ page import="codeu.model.store.basic.UserStore" %>
+<%@ page import="codeu.model.data.User" %>
+
 <%
 Conversation conversation = (Conversation) request.getAttribute("conversation");
 List<Message> messages = (List<Message>) request.getAttribute("messages");

--- a/src/main/webapp/WEB-INF/view/mentions.jsp
+++ b/src/main/webapp/WEB-INF/view/mentions.jsp
@@ -1,6 +1,9 @@
 <%@ page import="codeu.model.store.basic.UserStore" %>
 <%@ page import="codeu.model.store.basic.ConversationStore" %>
 <%@ page import="codeu.model.store.basic.MessageStore" %>
+<%@ page import="codeu.model.data.User" %>
+<%@ page import="codeu.model.data.Mention" %>
+
 
 <!DOCTYPE html>
 <html>
@@ -9,30 +12,32 @@
   <link rel="stylesheet" href="/css/main.css">
 </head>
 <body>
-  <%String name = (String) request.getSession().getAttribute("user");
-    int numUsers = UserStore.getInstance().getSize();
-    int numConvo = ConversationStore.getInstance().getSize();
-    int numChats = MessageStore.getInstance().getSize();
-    boolean admin = name != null && (name.equals("gaurijain") ||
-    name.equals("beckyqiu") || name.equals("mariorios"));%>
+  <%String name = (String) request.getSession().getAttribute("user");%>
   <nav>
     <a id="navTitle" href="/">CodeU Chat App</a>
     <a href="/conversations">Conversations</a>
-    <% if(admin) {%>
-      <a href="/admin.jsp">Admin</a>
-      <% } %> 
-    <% if(request.getSession().getAttribute("user") != null){%>
+    <% if(name != null){%>
       <a>Hello <%=name%>!</a>
       <a href="/mentions">Mentions</a>
     <% } else{ %>
       <a href="/login">Login</a>
     <% } %>
     <a href="/about.jsp">About</a>
+    <% boolean admin = name != null && UserStore.getInstance().isAdminRegistered(name);
+      if(admin) {%>
+      <a href="/admin">Admin</a>
+      <% } %>
   </nav>
   <div id="container">
     <div style="width:75%; margin-left:auto; margin-right:auto; margin-top: 50px;">
       <h1>Your Mentions</h1>
-      <p>You will show messages you were mentioned in here! (Not yet!)</p>
+      <p>You will show messages you were mentioned in here! <%
+      if(name!= null){
+        for (Mention x: UserStore.getInstance().getUser(name).getMentions()){
+        %><%=x.getMessage()%> <%=x.getConversation()%>
+        <%}
+      }%>
+      </p>
     </div>
   </div>
 </body>


### PR DESCRIPTION
<img width="1179" alt="screen shot 2018-07-18 at 12 22 02 am" src="https://user-images.githubusercontent.com/25145128/42866148-a07fbe5a-8a20-11e8-919a-0b0c7a0d0a40.png">

This is currently a bit ugly, but basically this mentions page is printing out the message and conversation attributes of the mentions arraylist inherent to the user. So for example, the first message I was tagged in was "@gaurijain tagged message 1" inside a conversation named "hello"

In order to implement this I have also added a mentions class, and I fixed some small things we were talking about yesterday in terms of entering the admin page from the mentions page. 

The chatservlet test is coming soon!