### PR TITLE
Added a mentions test page and ability to keep mentions after exiting and reentering appengine

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+import codeu.model.store.persistence.PersistentStorageAgent;
 
 /** Servlet class responsible for the chat page. */
 public class ChatServlet extends HttpServlet {
@@ -168,6 +169,7 @@ public class ChatServlet extends HttpServlet {
       }
       if (users.isUserRegistered(cleanedMessageContent.substring(startInd + 1, endInd))){
         users.getUser(cleanedMessageContent.substring(startInd+1, endInd)).addMentions(cleanedMessageContent, conversationTitle);
+        PersistentStorageAgent.getInstance().writeThrough(users.getUser(cleanedMessageContent.substring(startInd+1, endInd)));
         help = endInd;
       }
       else{

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -78,7 +78,6 @@ public class User {
     */
   public void setPersistentMentions(ArrayList<Mention> storedMentions){
     if (storedMentions == null){
-      System.out.println(storedMentions);
       return;
     }
     mentions = storedMentions;

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -68,7 +68,20 @@ public class User {
     return mentions;
   }
 
+  /** Adds a new mention to list of mentions*/
   public void addMentions(String msg, String conversation){
     mentions.add(new Mention(msg, conversation));
   }
+
+  /** Store the mentions from persistent storage into user's mentions. Should
+    * only be used for when persistent storage writes through stored information
+    */
+  public void setPersistentMentions(ArrayList<Mention> storedMentions){
+    if (storedMentions == null){
+      System.out.println(storedMentions);
+      return;
+    }
+    mentions = storedMentions;
+  }
+
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import codeu.model.data.Mention;
 
 /**
  * This class handles all interactions with Google App Engine's Datastore service. On startup it
@@ -68,6 +69,8 @@ public class PersistentDataStore {
         String passwordHash = (String) entity.getProperty("password_hash");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
         User user = new User(uuid, userName, passwordHash, creationTime);
+        user.setPersistentMentions(convertStringToMentionArr((ArrayList) entity.getProperty("mentions")));
+
         users.add(user);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -156,6 +159,7 @@ public class PersistentDataStore {
     userEntity.setProperty("username", user.getName());
     userEntity.setProperty("password_hash", user.getPasswordHash());
     userEntity.setProperty("creation_time", user.getCreationTime().toString());
+    userEntity.setProperty("mentions", convertMentionToStringArr(user.getMentions()));
     datastore.put(userEntity);
   }
 
@@ -179,5 +183,27 @@ public class PersistentDataStore {
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
     datastore.put(conversationEntity);
   }
-}
 
+  /** Convert Mentions to a valid property type. */
+  public ArrayList<String> convertMentionToStringArr(ArrayList<Mention> mentionArray){
+    ArrayList<String> stringArray = new ArrayList<String>();
+    for (Mention x: mentionArray){
+      stringArray.add(x.getMessage());
+      stringArray.add(x.getConversation());
+    }
+    return stringArray;
+  }
+
+  /** Convert String Array of mentions to Mention Array*/
+  public ArrayList<Mention> convertStringToMentionArr(ArrayList<String> stringArray){
+    ArrayList<Mention> mentionArray = new ArrayList<Mention>();
+    if (stringArray == null){
+      return mentionArray;
+    }
+    for (int i = 0; i < stringArray.size()-1; i++){
+      mentionArray.add(new Mention(stringArray.get(i), stringArray.get(i+1)));
+    }
+    return mentionArray;
+  }
+
+}

--- a/src/main/webapp/WEB-INF/view/mentions.jsp
+++ b/src/main/webapp/WEB-INF/view/mentions.jsp
@@ -4,7 +4,6 @@
 <%@ page import="codeu.model.data.User" %>
 <%@ page import="codeu.model.data.Mention" %>
 
-
 <!DOCTYPE html>
 <html>
 <head>

--- a/src/test/java/codeu/model/data/MentionTest.java
+++ b/src/test/java/codeu/model/data/MentionTest.java
@@ -1,0 +1,18 @@
+package codeu.model.data;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MentionTest {
+
+  @Test
+  public void testCreate() {
+    String message = "test mention @gaurijain";
+    String conversation = "test conversation";
+
+    Mention mention = new Mention(message, conversation);
+
+    Assert.assertEquals(message, mention.getMessage());
+    Assert.assertEquals(conversation, mention.getConversation());
+  }
+}


### PR DESCRIPTION
Unfortunately I don't have any good preview for this because it looks the same as before, just when you start up and log in on the app engine, the mentions page will be nonempty from your previous existing tags. Also mentions test is very simple. I created an issue for persistent storage tests I will work on. 

It isn't totally clear but entities can only be very specific values, so it can be a collection of allowed values like strings, which is why I created two helper functions to convert mentions to a string array and back to a mention array in the persistent storage class!